### PR TITLE
Fix weekdays sorting logic in normalizeArrays

### DIFF
--- a/scraper/lib/clean.ts
+++ b/scraper/lib/clean.ts
@@ -57,7 +57,11 @@ function normalizeArrays<T extends GenericDiscount>(discount: T): T {
     normalized.weekdays = [...normalized.weekdays].sort((a, b) => {
       const indexA = WEEKDAY_ORDER.indexOf(a as any);
       const indexB = WEEKDAY_ORDER.indexOf(b as any);
-      return indexA - indexB;
+      // If both found in order, use that order; otherwise sort alphabetically
+      if (indexA !== -1 && indexB !== -1) return indexA - indexB;
+      if (indexA !== -1) return -1;
+      if (indexB !== -1) return 1;
+      return a.localeCompare(b);
     });
   }
 


### PR DESCRIPTION
Improve `weekdays` sorting in `normalizeArrays` to correctly handle unknown values.

The previous logic incorrectly placed unknown weekdays at the beginning of the array and inconsistently ordered them. This change aligns the sorting behavior with `membership` and `where` fields, placing unknown items after known ones and sorting them alphabetically.