### PR TITLE
Switch to supercronic for cron jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update && apt-get install -y \
     curl \
     wget \
     unzip \
-    cron \
     tzdata \
     ca-certificates \
     fonts-liberation \
@@ -39,6 +38,17 @@ RUN apt-get update && apt-get install -y \
     xvfb \
     git \
     && rm -rf /var/lib/apt/lists/*
+
+# Install supercronic
+ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.29/supercronic-linux-amd64 \
+    SUPERCRONIC=supercronic-linux-amd64 \
+    SUPERCRONIC_SHA1SUM=cd48d45c4b10f3f0bfdd3a57d054cd05ac96812b
+
+RUN curl -fsSLO "$SUPERCRONIC_URL" \
+    && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
+    && chmod +x "$SUPERCRONIC" \
+    && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
+    && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
 
 # Install Node.js (required for bun installation)
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
@@ -75,15 +85,8 @@ COPY infra/run-scraper.sh /usr/local/bin/run-scraper.sh
 COPY infra/start-container.sh /usr/local/bin/start-container.sh
 RUN chmod +x /usr/local/bin/run-scraper.sh /usr/local/bin/start-container.sh
 
-# Create cron job for Mondays and Fridays at 9:00 AM UTC-3
-RUN echo "0 9 * * 1,5 /usr/local/bin/run-scraper.sh" > /etc/cron.d/scraper-schedule
-
-# Give execution permissions on the cron job
-RUN chmod 0644 /etc/cron.d/scraper-schedule
-
-# Apply cron job
-RUN crontab /etc/cron.d/scraper-schedule
-
+# Create crontab file for supercronic - Mondays and Fridays at 9:00 AM UTC-3
+RUN echo "0 9 * * 1,5 /usr/local/bin/run-scraper.sh" > /app/crontab
 
 # Environment variables (override these when running container)
 ENV HEADLESS=false
@@ -96,9 +99,9 @@ ENV FETCH_CACHER_ENDPOINT=https://s3.us-west-002.backblazeb2.com
 # Expose any ports if needed (not required for this scraper)
 # EXPOSE 3000
 
-# Health check
+# Health check - check if supercronic is running
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-  CMD ps aux | grep -v grep | grep cron || exit 1
+  CMD ps aux | grep -v grep | grep supercronic || exit 1
 
 # Run the startup script
 CMD ["/usr/local/bin/start-container.sh"]

--- a/infra/run-scraper.sh
+++ b/infra/run-scraper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-echo "$(date): Starting scraper execution" >> /var/log/scraper/cron.log
+echo "$(date): Starting scraper execution" >> /var/log/scraper/scheduler.log
 
 # Set display for headful browser
 export DISPLAY=:99
@@ -18,10 +18,10 @@ sleep 3
 cd /app/scraper
 
 # Run all scrapers with save flag
-echo "$(date): Running scrapers..." >> /var/log/scraper/cron.log
-bun run cli all --save --telegram 2>&1 | tee -a /var/log/scraper/cron.log
+echo "$(date): Running scrapers..." >> /var/log/scraper/scheduler.log
+bun run cli all --save --telegram 2>&1 | tee -a /var/log/scraper/scheduler.log
 
 # Clean up
 kill $XVFB_PID 2>/dev/null || true
 
-echo "$(date): Scraper execution completed" >> /var/log/scraper/cron.log
+echo "$(date): Scraper execution completed" >> /var/log/scraper/scheduler.log

--- a/infra/start-container.sh
+++ b/infra/start-container.sh
@@ -11,10 +11,10 @@ if [ "$RUN_MODE" = "once" ]; then
     exit 0
 fi
 
-# Default: run with cron scheduling
+# Default: run with supercronic scheduling
 echo "Next scheduled runs:"
 echo "- Mondays at 9:00 AM"
 echo "- Fridays at 9:00 AM"
 
-# Start cron in foreground
-cron -f
+# Start supercronic with the crontab file
+exec supercronic /app/crontab


### PR DESCRIPTION
Replace `cron` with `supercronic` for more reliable scheduling in the Docker environment.

---

[Open in Web](https://cursor.com/agents?id=bc-3df2efa2-cf32-4c8b-9868-7d85ba20425e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-3df2efa2-cf32-4c8b-9868-7d85ba20425e) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)